### PR TITLE
Automatic update of xunit to 2.4.1

### DIFF
--- a/src/Easify.AspNetCore.Bootstrap.UnitTests/Easify.AspNetCore.Bootstrap.UnitTests.csproj
+++ b/src/Easify.AspNetCore.Bootstrap.UnitTests/Easify.AspNetCore.Bootstrap.UnitTests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Easify.AspNetCore.UnitTests/Easify.AspNetCore.UnitTests.csproj
+++ b/src/Easify.AspNetCore.UnitTests/Easify.AspNetCore.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Easify.ExceptionHandling.UnitTests/Easify.ExceptionHandling.UnitTests.csproj
+++ b/src/Easify.ExceptionHandling.UnitTests/Easify.ExceptionHandling.UnitTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Easify.Extensions.UnitTests/Easify.Extensions.UnitTests.csproj
+++ b/src/Easify.Extensions.UnitTests/Easify.Extensions.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Easify.Logging.UnitTests/Easify.Logging.UnitTests.csproj
+++ b/src/Easify.Logging.UnitTests/Easify.Logging.UnitTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Samples/Easify.Sample.WebAPI.IntegrationTests/Easify.Sample.WebAPI.IntegrationTests.csproj
+++ b/src/Samples/Easify.Sample.WebAPI.IntegrationTests/Easify.Sample.WebAPI.IntegrationTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `xunit` to `2.4.1` from `2.3.1`
`xunit 2.4.1` was published at `2018-10-29T04:18:23Z`, 1 year and 1 month ago

6 project updates:
Updated `src\Easify.AspNetCore.Bootstrap.UnitTests\Easify.AspNetCore.Bootstrap.UnitTests.csproj` to `xunit` `2.4.1` from `2.3.1`
Updated `src\Easify.AspNetCore.UnitTests\Easify.AspNetCore.UnitTests.csproj` to `xunit` `2.4.1` from `2.3.1`
Updated `src\Easify.ExceptionHandling.UnitTests\Easify.ExceptionHandling.UnitTests.csproj` to `xunit` `2.4.1` from `2.3.1`
Updated `src\Easify.Extensions.UnitTests\Easify.Extensions.UnitTests.csproj` to `xunit` `2.4.1` from `2.3.1`
Updated `src\Easify.Logging.UnitTests\Easify.Logging.UnitTests.csproj` to `xunit` `2.4.1` from `2.3.1`
Updated `src\Samples\Easify.Sample.WebAPI.IntegrationTests\Easify.Sample.WebAPI.IntegrationTests.csproj` to `xunit` `2.4.1` from `2.3.1`

[xunit 2.4.1 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
