### PR TITLE
Automatic update of Newtonsoft.Json to 12.0.3

### DIFF
--- a/src/Easify.ExceptionHandling/Easify.ExceptionHandling.csproj
+++ b/src/Easify.ExceptionHandling/Easify.ExceptionHandling.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestEase" Version="1.4.4" />
   </ItemGroup>
 

--- a/src/Easify.Logging/Easify.Logging.csproj
+++ b/src/Easify.Logging/Easify.Logging.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Easify.Testing.Core/Easify.Testing.Core.csproj
+++ b/src/Easify.Testing.Core/Easify.Testing.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `12.0.3` from `10.0.3`
`Newtonsoft.Json 12.0.3` was published at `2019-11-09T01:27:30Z`, 10 days ago

3 project updates:
Updated `src\Easify.ExceptionHandling\Easify.ExceptionHandling.csproj` to `Newtonsoft.Json` `12.0.3` from `10.0.3`
Updated `src\Easify.Logging\Easify.Logging.csproj` to `Newtonsoft.Json` `12.0.3` from `10.0.3`
Updated `src\Easify.Testing.Core\Easify.Testing.Core.csproj` to `Newtonsoft.Json` `12.0.3` from `10.0.3`

[Newtonsoft.Json 12.0.3 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/12.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
