### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.4.0

### DIFF
--- a/src/Easify.AspNetCore.Bootstrap.UnitTests/Easify.AspNetCore.Bootstrap.UnitTests.csproj
+++ b/src/Easify.AspNetCore.Bootstrap.UnitTests/Easify.AspNetCore.Bootstrap.UnitTests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Easify.AspNetCore.UnitTests/Easify.AspNetCore.UnitTests.csproj
+++ b/src/Easify.AspNetCore.UnitTests/Easify.AspNetCore.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Foil" Version="1.0.30" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Easify.ExceptionHandling.UnitTests/Easify.ExceptionHandling.UnitTests.csproj
+++ b/src/Easify.ExceptionHandling.UnitTests/Easify.ExceptionHandling.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Easify.Extensions.UnitTests/Easify.Extensions.UnitTests.csproj
+++ b/src/Easify.Extensions.UnitTests/Easify.Extensions.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Easify.Logging.UnitTests/Easify.Logging.UnitTests.csproj
+++ b/src/Easify.Logging.UnitTests/Easify.Logging.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Samples/Easify.Sample.WebAPI.IntegrationTests/Easify.Sample.WebAPI.IntegrationTests.csproj
+++ b/src/Samples/Easify.Sample.WebAPI.IntegrationTests/Easify.Sample.WebAPI.IntegrationTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.NET.Test.Sdk` to `16.4.0` from `15.5.0`
`Microsoft.NET.Test.Sdk 16.4.0` was published at `2019-11-06T10:50:48Z`, 13 days ago

6 project updates:
Updated `src\Easify.AspNetCore.Bootstrap.UnitTests\Easify.AspNetCore.Bootstrap.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.5.0`
Updated `src\Easify.AspNetCore.UnitTests\Easify.AspNetCore.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.5.0`
Updated `src\Easify.ExceptionHandling.UnitTests\Easify.ExceptionHandling.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.5.0`
Updated `src\Easify.Extensions.UnitTests\Easify.Extensions.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.5.0`
Updated `src\Easify.Logging.UnitTests\Easify.Logging.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.5.0`
Updated `src\Samples\Easify.Sample.WebAPI.IntegrationTests\Easify.Sample.WebAPI.IntegrationTests.csproj` to `Microsoft.NET.Test.Sdk` `16.4.0` from `15.5.0`

[Microsoft.NET.Test.Sdk 16.4.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
